### PR TITLE
Fixed version selection bug

### DIFF
--- a/src/TinyAccountManager.Droid/AccountManager.cs
+++ b/src/TinyAccountManager.Droid/AccountManager.cs
@@ -16,7 +16,7 @@ namespace TinyAccountManager.Droid
     {
             public static void Initialize()
             {
-                if (Build.VERSION.SdkInt > BuildVersionCodes.M)
+                if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
                     Abstraction.AccountManager.Current = new AndroidAccountManager();
                 else
                     Abstraction.AccountManager.Current = new AndroidAccountManagerPreM(Application.Context, "AccountManagerSharedPreferences");


### PR DESCRIPTION
Fixed a bug when choosing which AccountManager to use. It should now work correctly for Marshmallow as well.